### PR TITLE
Make curl verbose and never return failure

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -168,7 +168,7 @@ if [ ! -z "$CODECOV_TOKEN" ] ; then
   echo ::group::codecov
   make coverage VERBOSE=1
 
-  curl -s https://codecov.io/bash > codecov.sh
+  curl -v https://codecov.io/bash > codecov.sh
 
   # disable gcov output with `-X gcovout -X gcov`
   bash codecov.sh -t $CODECOV_TOKEN -X gcovout -X gcov

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -168,7 +168,7 @@ if [ ! -z "$CODECOV_TOKEN" ] ; then
   echo ::group::codecov
   make coverage VERBOSE=1
 
-  curl -v https://codecov.io/bash > codecov.sh
+  curl -v -f https://codecov.io/bash > codecov.sh
 
   # disable gcov output with `-X gcovout -X gcov`
   bash codecov.sh -t $CODECOV_TOKEN -X gcovout -X gcov


### PR DESCRIPTION
Actions often fail on this line without much explanation. This makes it verbose so we can see what's going on, and it should also allow it to go through without returning an error code. Depending on the failure mode, this may just be pushing the error to the next line.