### PR TITLE
Fixed path for make test

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -150,6 +150,7 @@ fi
 
 echo ::group::make test
 export CTEST_OUTPUT_ON_FAILURE=1
+cd "$GITHUB_WORKSPACE"/build
 make test
 echo ::endgroup::
 


### PR DESCRIPTION
Some of the `after_make.sh` scripts may change the working directory [like this one in ign-common]( https://github.com/ignitionrobotics/ign-common/blob/master/.github/ci-bionic/after_make.sh). The line will restore the right directory to run the tests.

Here an example of a failured: https://github.com/ignitionrobotics/ign-common/pull/90/checks?check_run_id=1061729023

Signed-off-by: ahcorde <ahcorde@gmail.com>