### PR TITLE
Source the libraries before executing the tests

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -154,6 +154,7 @@ fi
 echo ::group::make test
 export CTEST_OUTPUT_ON_FAILURE=1
 cd "$GITHUB_WORKSPACE"/build
+. colcon_command_prefix_test.sh
 make test
 echo ::endgroup::
 


### PR DESCRIPTION
We are having some problem with the [ignition-sensors tests](https://github.com/ignitionrobotics/ign-sensors/pull/38/checks?check_run_id=1114769480). When we are executing the tests some libraries are not availables. This is because the ignition libraries are not sourced. 

This should be ported to master too.

@chapulina @j-rivero 

Signed-off-by: ahcorde <ahcorde@gmail.com>