### PR TITLE
Replace tools/code_check.sh with 'make codecheck'

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -94,10 +94,6 @@ if [ -f "$SOURCE_DEPENDENCIES" ] || [ -f "$SOURCE_DEPENDENCIES_VERSIONED" ] ; th
   echo ::endgroup::
 fi
 
-echo ::group::Code check
-sh tools/code_check.sh 2>&1
-echo ::endgroup::
-
 echo ::group::Build folder
 mkdir build
 cd build
@@ -119,6 +115,18 @@ if [ ! -z "$CODECOV_TOKEN" ] ; then
   cmake .. $CMAKE_ARGS -DCMAKE_BUILD_TYPE=coverage
 else
   cmake .. $CMAKE_ARGS
+fi
+echo ::endgroup::
+
+echo ::group::Code check
+# only run `make codecheck` if the Makefile has a `codecheck` target
+# (default to tools/code_check.sh otherwise)
+if grep -iq codecheck Makefile; then
+  make codecheck 2>&1
+else
+  cd ..
+  sh tools/code_check.sh 2>&1
+  cd build
 fi
 echo ::endgroup::
 


### PR DESCRIPTION
With the new `ign-cmake` release coming out (`2.6.0` - https://github.com/ignitionrobotics/ign-cmake/pull/131), we should run `make codecheck` in GitHub actions instead of running `tools/code_check.sh` so that we can make sure users are adhering to the new code checker introduced in https://github.com/ignitionrobotics/ign-cmake/pull/117.

I haven't tested this locally because I'm not sure how to, since it's a change for GitHub actions... does anyone know how to test this/would anyone be willing to test this?

Also, once this is merged and `ign-cmake-2.6.0` is released, we will need to update all affected repositories to make sure that CI isn't broken due to being unable to pass `make codecheck` in GitHub actions (most repositories were already updated a few weeks ago in anticipation for this `ign-cmake` release, but I'm sure changes have been made to these repositories since things were updated a few weeks ago).

Signed-off-by: Ashton Larkin <ashton@openrobotics.org>