### PR TITLE
Move focal out of gcc8 to gcc9 (default)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -62,13 +62,6 @@ make install
 cd ..
 echo ::endgroup::
 
-echo ::group::GCC 8
-update-alternatives \
-  --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 \
-  --slave /usr/bin/g++ g++ /usr/bin/g++-8 \
-  --slave /usr/bin/gcov gcov /usr/bin/gcov-8
-echo ::endgroup::
-
 if [ -f "$SOURCE_DEPENDENCIES" ] || [ -f "$SOURCE_DEPENDENCIES_VERSIONED" ] ; then
   echo ::group::Fetch source dependencies
   mkdir -p deps/src


### PR DESCRIPTION
Remove the code coming from Bionic that forces gcc8. gcc9 is default on Focal
